### PR TITLE
object: Adjusted object-curly-newline option to not be that ugly in the code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -113,9 +113,9 @@
     ],
 
     "object-curly-newline": ["error", {
-      "ObjectExpression": "always",
+      "ObjectExpression": { "consistent": true, "minProperties": 1 },
       "ObjectPattern": { "multiline": true },
-      "ImportDeclaration": "always",
+      "ImportDeclaration": { "consistent": true, "minProperties": 3 },
       "ExportDeclaration": { "multiline": true, "minProperties": 3 }
     }]
   }


### PR DESCRIPTION
newline is only required in imports with 3 or more properties and object expressions require newlines for 1 or more properties. This makes the code much more readable since `const example = {};` is valid, while `const example = { foo: bar };` is not. The consistent allows us to still allow the multiline way without having issues. This is good for a cleaner adjustment over all projects without many issues.