### PR TITLE
Enabled warnings for double quotes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,7 +90,7 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
-
+    "quotes": ["warn", "single"],
     "max-len": [
       "error",
       {


### PR DESCRIPTION
Can be set in .editorconfig using the `ij_typescript_use_double_quotes = false` rule or in Intellij IDEs settings `Editor > Code Style > JavaScript > Punctuation > Use single quotes in new code`

Example of **incorrect** code for this rule with the `single` option:
```javascript
/*eslint quotes: ["error", "single"]*/

var double = "double";
var unescaped = "a string containing 'single' quotes";
var newline = "new/nline";
```

Examples of **correct** code for this rule with the "single" option:
```javascript
/*eslint quotes: ["error", "single"]*/
/*eslint-env es6*/

var single = 'single';
var backtick = `back${x}tick`; // backticks are allowed due to substitution
var newline = 'new/nline';
```