### PR TITLE
Set quotes rule from warn to error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,7 +90,7 @@
         "caughtErrorsIgnorePattern": "^_"
       }
     ],
-    "quotes": ["warn", "single"],
+    "quotes": ["error", "single"],
     "max-len": [
       "error",
       {


### PR DESCRIPTION
Since there are no problems reported in last weeks, enforce the quotes rule.

Note: This will throw eslint errors when the existing code in the project was not yet fixed for single quotes.