### PR TITLE
Adjusted linting to ignore indentation for conditional expressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,7 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "error",
     "object-curly-spacing": "off",
-    "indent": ["warn", 2, { "ignoredNodes": ["PropertyDefinition"] }],
+    "indent": ["warn", 2, { "ignoredNodes": ["PropertyDefinition", "ConditionalExpression"] }],
     "no-mixed-spaces-and-tabs": "off",
     "padded-blocks": "off",
     "brace-style": "off",


### PR DESCRIPTION
Currently the linting will force a multiline ternary operator to be written like in the following:
```
ProductState.ProductionReady].includes(this.productState)
? deadline < DateTime.now() && this.totalWorkSteps > 0
: false;
```

Though "correct" (or more readable) would be the following:
```
ProductState.ProductionReady].includes(this.productState)
  ? deadline < DateTime.now() && this.totalWorkSteps > 0
  : false;
```

The only disadvantage is that theoretically this would be also valid, though sadly there is no other setting to split it thurther...
```
var a = foo
                ? bar
: baz;
```